### PR TITLE
Allow ignoring whole device families

### DIFF
--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -33,13 +33,13 @@ class MQTTClient(multiprocessing.Process):
 
     def _on_connect(self, client, userdata, flags, rc):
         if rc == 0:
-            self.logger.info("Connected to broker. Return code: %d" % rc)
+            self.logger.info("Connected to broker. Return code: %s" % mqtt.connack_string(rc))
         else:
-            self.logger.warning("An error occured on connect. Return code: %d " % rc)
+            self.logger.warning("An error occured on connect. Return code: %s " % mqtt.connack_string(rc))
 
     def _on_disconnect(self, client, userdata, rc):
         if rc != 0:
-            self.logger.error("Unexpected disconnection.")
+            self.logger.error("Unexpected disconnection. Return code: %s" % mqtt.connack_string(rc))
             self._mqttConn.reconnect()
 
     def _on_publish(self, client, userdata, mid):

--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -15,11 +15,17 @@ class MQTTClient(multiprocessing.Process):
         self.messageQ = messageQ
         self.commandQ = commandQ
 
+        self.config = config
+        self.auth = None
+        self.host = config['mqtt_host']
+        self.port = config['mqtt_port']
+
         self.mqttDataPrefix = config['mqtt_prefix']
         self._mqttConn = mqtt.Client(client_id='RFLinkGateway')
         if config['mqtt_user'] is not None:
             self.logger.info("Connection with credentials (user: %s).", config['mqtt_user'])
             self._mqttConn.username_pw_set(username=config['mqtt_user'], password=config['mqtt_password'])
+            self.auth = {'username': config['mqtt_user'], 'password': config['mqtt_password']}
         self._mqttConn.connect(config['mqtt_host'], port=config['mqtt_port'], keepalive=120)
 
         self._mqttConn.on_connect = self._on_connect
@@ -63,8 +69,9 @@ class MQTTClient(multiprocessing.Process):
     def publish(self, task):
         topic = "%s/%s/%s/R/%s" % (self.mqttDataPrefix, task['family'], task['deviceId'], task['param'])
         try:
-            self._mqttConn.publish(topic, payload=task['payload'])
             self.logger.debug('Sending:%s' % (task))
+            #self._mqttConn.publish(topic, payload=task['payload'])
+            publish.single(topic, payload=task['payload'], hostname=self.host, auth=self.auth, port=self.port)
         except Exception as e:
             self.logger.error('Publish problem: %s' % (e))
             self.messageQ.put(task)

--- a/SerialProcess.py
+++ b/SerialProcess.py
@@ -31,7 +31,8 @@ class SerialProcess(multiprocessing.Process):
 
     def prepare_output(self, data_in):
         out = []
-        data = data_in.decode("ascii").replace(";\r\n", "").split(";")
+        msg = data_in.decode("ascii")
+        data = msg.replace(";\r\n", "").split(";")
 
         if len(data) > 1 and data[1] == '00':
             self.logger.info("%s" % (data[2]))
@@ -39,10 +40,12 @@ class SerialProcess(multiprocessing.Process):
             self.logger.debug("Received message:%s" % (data))
 
         if len(data) > 3 and data[0] == '20':
-            deviceId = data[3].split("=")[1]
-            if deviceId not in self.ignored_devices:
-                family = data[2]
-                d = {}
+            family = data[2]
+            deviceId = data[3].split("=")[1]  # TODO: For some debug messages there is no =
+            if (deviceId not in self.ignored_devices and
+                family not in self.ignored_devices and
+                "%s/%s" % (family, deviceId) not in self.ignored_devices):
+                d = {'message': msg}
                 for t in data[4:]:
                     token = t.split("=")
                     d[token[0]] = token[1]

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
   "mqtt_message_timeout": 60,
   "rflink_tty_device": "/dev/ttyUSB0",
   "rflink_direct_output_params": [
+    "message",
     "BAT",
     "CMD",
     "SET_LEVEL",
@@ -16,5 +17,10 @@
     "PIR",
     "SMOKEALERT"
   ],
-  "rflink_ignored_devices": []
+  "rflink_ignored_devices": [
+    "Friedland", 
+    "Oregon Temp/FD10",
+    "BL999",
+    "RTS"
+  ]
 }


### PR DESCRIPTION
I recently started using / improving the RFLinkGateway from iture myself, and it seems we made basically identical changes. 

What I also implemented, and which I include in this PR:

- Allow ignoring whole device families, i.e. the rflink_ignored_devices can also hold the name of a device family, or a device family and device ID (in case there are two devices with idential ID but from different families). Example:
`  "rflink_ignored_devices": [
    "Friedland", 
    "Oregon Temp/FD10",
    "BL999",
    "RTS"
  ]`
- Using paho.mqtt.publish.single with authentication to submit each topic to the mqtt broker. Using the existing connection (like you do, and like I originally did) should not be a problem in general, but for me the connection typically breaks down after a day or two and does NOT automatically reconnect, so one is forced to restart the RFLinkGateway to get it working again. Using a separate, new connection for each topic might improve this problem, so only receiving changes from the mqtt broker will fail, but at least the sensor values will be properly sent to the mqtt broker.
- The error codes (rc variable) for the mqtt connection handlers can be transformed into a human-readable string, which I include into the error message.


I've been running these changes for a few days now, and I'm not experiencing any issues so far.

PS: Using env vars for the conf and log file and the log level is a great idea, which I didn't come up with...