### PR TITLE
Usability fix: removing mqtt_user from configuration file disables mqtt authentication instead of crashing. 

### DIFF
--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -22,7 +22,7 @@ class MQTTClient(multiprocessing.Process):
 
         self.mqtt_data_prefix = config['mqtt_prefix']
         self._mqttConn = mqtt.Client(client_id='RFLinkGateway')
-        if config['mqtt_user'] is not None:
+        if 'mqtt_user' in config and config['mqtt_user'] is not None:
             self.logger.info("Connection with credentials (user: %s).", config['mqtt_user'])
             self._mqttConn.username_pw_set(username=config['mqtt_user'], password=config['mqtt_password'])
             self.auth = {'username': config['mqtt_user'], 'password': config['mqtt_password']}


### PR DESCRIPTION
A minor change to check if mqtt_user is available in the configuration file or not, and if not, it doesn't use mqtt_authentication.  
I found this more intuitive than putting "None" for user, and the original code crashed if the config key was removed. 
(My original perception was a bug, hence the original commit msg. After reading up on json/python, I consider it an UX thing)
